### PR TITLE
Corrected (another) syntax error in Powell's link

### DIFF
--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -3,7 +3,7 @@
 
 ## Places to Visit
   * [Oregon Zoo](portland-zoo.md)
-  * [Powell's City of Books] (powells.md)
+  * [Powell's City of Books](powells.md)
 
 ## Places to Eat or Drink 
   * [Rogue Farms](rogue-farms.md)


### PR DESCRIPTION
Accidentally left a space between the link text and the URL. Corrected!